### PR TITLE
alembic 1.10.2

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,6 @@
 {% set name = "alembic" %}
-{% set version = "1.8.1" %}
-{% set hash = "cd0b5e45b14b706426b833f06369b9a6d5ee03f826ec3238723ce8caaf6e5ffa" %}
+{% set version = "1.10.2" %}
+{% set hash = "457eafbdc0769d855c2c92cbafe6b7f319f916c80cf4ed02b8f394f38b51b89d" %}
 {% set bundle = "tar.gz" %}
 
 package:


### PR DESCRIPTION
**Recipe directory diff between current master and this update:**
``` diff
diff --git a/recipe/meta.yaml b/recipe/meta.yaml
index 1b73f8a..d09d967 100644
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,6 @@
 {% set name = "alembic" %}
-{% set version = "1.8.1" %}
-{% set hash = "cd0b5e45b14b706426b833f06369b9a6d5ee03f826ec3238723ce8caaf6e5ffa" %}
+{% set version = "1.10.2" %}
+{% set hash = "457eafbdc0769d855c2c92cbafe6b7f319f916c80cf4ed02b8f394f38b51b89d" %}
 {% set bundle = "tar.gz" %}
 
 package:

```


**Jira ticket:** [PKG-125](https://anaconda.atlassian.net/browse/PKG-125) (alembic-1.8.1)

**The upstream data:**
Github releases:  https://github.com/sqlalchemy/alembic/releases
[Diff between the latest and previous upstream releases](https://github.com/sqlalchemy/alembic/compare/1.8.1...1.10.2)
Changelog: https://github.com/sqlalchemy/alembic/blob/main/CHANGES
Requirements:

**_Actions:_**

1. 

**_Notes:_**
 * 

**Additional info:**

<details>

**Package's statistics**

<details>

 * Priority D | effort: easy | Category: other_key_deps | subcategory:  | pkg_type: python
 * Outdated platforms: 'linux-64', 'linux-aarch64', 'linux-ppc64le', 'osx-64', 'osx-arm64', 'win-64'
 * Latest version: 1.10.2
 * Release on PyPi:
    * version: 1.10.2
    * date: 2023-03-08T17:17:49
* [PyPi history](https://pypi.org/project/alembic/#history)
 * Popularity: 
    * 3 months downloads: 136307.0
    * All time:  3167961 downloads -  alembic  1.10.2  A database migration tool for SQLAlchemy.  

</details>

**Other checks:**

<details>

1. - [ ] Check the pinnings
2. - [ ] Verify that the 'build_number' is correct
3. - [x] has 'setuptools'
5. - [x] has 'wheel'
7. - [x] 'pip' in test
9. - [ ] Verify the test section
10. - [ ] Verify if the package is 'architecture specific'
11. - [ ] Verify that private modules are not mentioned in the recipe For example: (_private_module)
12.  - [x] license_file: LICENSE is present

14. - [x] license_family MIT is present
16. - [x] License: MIT
    - [x] License is 'spdx' compliant
 * Check if the license identifier has correct name from the SPDX License List

| Identifier                       |
|:---------------------------------|
| HPND-sell-variant-MIT-disclaimer |
| MIT                              |
| MIT-0                            |
| MIT-advertising                  |
| MIT-CMU                          |
| MIT-enna                         |
| MIT-feh                          |
| MIT-Modern-Variant               |
| MIT-open-group                   |
| MIT-Wu                           |
| MITNFA                           |
</details>

**Check dependency issues:**

<details>
../aggregate/alembic-feedstock/recipe/meta.yaml
Dependencies: ['mako', 'pip', 'setuptools >=47', 'python', 'wheel', 'python-dateutil', 'sqlalchemy >=1.3.0']


noarch:
- py3.8:  No issues found
- py3.9:  No issues found
- py3.10:  No issues found
- py3.11:  No issues found

linux-64:
- py3.8:  No issues found
- py3.9:  No issues found
- py3.10:  No issues found
- py3.11:  No issues found

linux-ppc64le:
- py3.8:  No issues found
- py3.9:  No issues found
- py3.10:  No issues found
- py3.11:  No issues found

linux-s390x:
- py3.8:  No issues found
- py3.9:  No issues found
- py3.10:  No issues found
- py3.11:  No issues found

osx-64:
- py3.8:  No issues found
- py3.9:  No issues found
- py3.10:  No issues found
- py3.11:  No issues found

osx-arm64:
- py3.8:  No issues found
- py3.9:  No issues found
- py3.10:  No issues found
- py3.11:  No issues found

win-64:
- py3.8:  No issues found
- py3.9:  No issues found
- py3.10:  No issues found
- py3.11:  No issues found

</details>
**Other:**

<details>
Checking 'alembic' recipe...
~/Library/CloudStorage/OneDrive-SoftServe,Inc/src/aggregate/alembic-feedstock/recipe ~/Library/CloudStorage/OneDrive-SoftServe,Inc/src/finder
--- Build Requirements ---
>> Empty Host Section <<
--- Host Requirements ---
pip: main
setuptools >=47: main
wheel: main
--- Run Requirements ---
mako: main
sqlalchemy >=1.3.0: main
importlib-metadata: main
importlib_resources: main
python-dateutil: main
~/Library/CloudStorage/OneDrive-SoftServe,Inc/src/finder

</details>

<details>

https://repo.anaconda.com/pkgs/main/noarch
https://repo.anaconda.com/pkgs/main/linux-64
alembic-1.8.1-py311h06a4308_0.tar.bz2
alembic-1.8.1-py310h06a4308_0.tar.bz2
alembic-1.8.1-py39h06a4308_0.tar.bz2
alembic-1.8.1-py38h06a4308_0.tar.bz2
alembic-1.8.1-py37h06a4308_0.tar.bz2
https://repo.anaconda.com/pkgs/main/linux-ppc64le
alembic-1.8.1-py39h6ffa863_0.tar.bz2
alembic-1.8.1-py311h6ffa863_0.tar.bz2
alembic-1.8.1-py37h6ffa863_0.tar.bz2
alembic-1.8.1-py310h6ffa863_0.tar.bz2
alembic-1.8.1-py38h6ffa863_0.tar.bz2
https://repo.anaconda.com/pkgs/main/linux-aarch64/
alembic-1.8.1-py39hd43f75c_0.tar.bz2
alembic-1.8.1-py311hd43f75c_0.tar.bz2
alembic-1.8.1-py38hd43f75c_0.tar.bz2
alembic-1.8.1-py37hd43f75c_0.tar.bz2
alembic-1.8.1-py310hd43f75c_0.tar.bz2
https://repo.anaconda.com/pkgs/main/linux-s390x/
alembic-1.8.1-py37ha847dfd_0.tar.bz2
alembic-1.8.1-py310ha847dfd_0.tar.bz2
alembic-1.8.1-py38ha847dfd_0.tar.bz2
alembic-1.8.1-py311ha847dfd_0.tar.bz2
alembic-1.8.1-py39ha847dfd_0.tar.bz2
https://repo.anaconda.com/pkgs/main/osx-64
alembic-1.8.1-py39hecd8cb5_0.tar.bz2
alembic-1.8.1-py38hecd8cb5_0.tar.bz2
alembic-1.8.1-py310hecd8cb5_0.tar.bz2
alembic-1.8.1-py311hecd8cb5_0.tar.bz2
alembic-1.8.1-py37hecd8cb5_0.tar.bz2
https://repo.anaconda.com/pkgs/main/osx-arm64/
alembic-1.8.1-py39hca03da5_0.tar.bz2
alembic-1.8.1-py38hca03da5_0.tar.bz2
alembic-1.8.1-py310hca03da5_0.tar.bz2
alembic-1.8.1-py311hca03da5_0.tar.bz2
https://repo.anaconda.com/pkgs/main/win-64
alembic-1.8.1-py310haa95532_0.tar.bz2
alembic-1.8.1-py38haa95532_0.tar.bz2
alembic-1.8.1-py311haa95532_0.tar.bz2
alembic-1.8.1-py39haa95532_0.tar.bz2
alembic-1.8.1-py37haa95532_0.tar.bz2

</details>

<details>

               name  version                  spec
0           airflow    2.4.3  alembic >=1.5.1,<2.0
1           airflow    2.3.3  alembic >=1.5.1,<2.0
2           airflow  1.10.12    alembic >=1.0,<2.0
3           airflow  1.10.10    alembic >=1.0,<2.0
4           airflow   1.10.7    alembic >=1.0,<2.0
5        jupyterhub    3.1.1         alembic >=1.4
6        jupyterhub    3.1.0         alembic >=1.4
7        jupyterhub    2.0.0         alembic >=1.4
8        jupyterhub    1.4.2         alembic >=1.4
9        jupyterhub    1.4.1         alembic >=1.4
10       jupyterhub    1.0.0               alembic
11       jupyterhub    0.9.6               alembic
12       jupyterhub    0.9.5               alembic
13       jupyterhub    0.9.4               alembic
14  jupyterhub-base    1.3.0               alembic

</details>

**Package Build Score: 21**





**Links:**
* [Anaconda Recipes feedstock](https://github.com/AnacondaRecipes/alembic-feedstock)
* [Update branch](https://github.com/AnacondaRecipes/alembic-feedstock/tree/1.10.2)
* [conda-forge recipe](https://github.com/conda-forge/{feedstock_name}-feedstock)
* [PyPI](https://pypi.org/project/alembic)
* [Diff between upstream and feature branch](https://github.com/conda-forge/alembic-feedstock/compare/main...AnacondaRecipes:1.10.2)
* [Diff between origin and feature branch](https://github.com/AnacondaRecipes/alembic-feedstock/compare/master...AnacondaRecipes:1.10.2)
* [The last merged PRs](https://github.com/AnacondaRecipes/alembic-feedstock/pulls?q=is%3Apr+is%3Amerged+sort%3Aupdated-desc+)


</details>

**Updating the recipe:**
If the recipe needs additional modification the update branch can be modified. Note that the PR diffs are not updated with these changes.
```
git clone -b 1.10.2 git@github.com:AnacondaRecipes/alembic-feedstock.git
```


[PKG-125]: https://anaconda.atlassian.net/browse/PKG-125?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[PKG-125]: https://anaconda.atlassian.net/browse/PKG-125?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ